### PR TITLE
chore: 모바일 및 PC release drafter 제거

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,24 +7,6 @@ on:
       - feat/mono-repo
 
 jobs:
-  mobile-seller:
-    name: 'Release Drafter - mobile-seller'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: release-drafter/release-drafter@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          config-name: release-drafter-mobile-seller.yml
-  pc-seller:
-    name: 'Release Drafter - pc-seller'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: release-drafter/release-drafter@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          config-name: release-drafter-pc-seller.yml
   webview:
       name: 'Release Drafter - webview'
       runs-on: ubuntu-latest


### PR DESCRIPTION
모바일 및 PC 판매자 관련 작업을 릴리즈 드래프트에서 제거하고 웹뷰 작업만 남겼습니다.

Generated by Copilot